### PR TITLE
ITD-940 Ensure retry_all retries expired jobs 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+### Unreleased
+#### Fixed:
+- Fixed inconsistent pagination when several jobs have the same `run_at`
+
 ### 0.9.3 - 2020-06-17
 #### Added:
 - Set expired_at=NULL when rescheduling job

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+### 0.9.3 - 2020-06-17
+#### Added:
+- Set expired_at=NULL when rescheduling job
+- Make job search case-insensitive
+- Allow to search by ActiveJob class name
+
 ### 0.9.2 - 2020-04-24
 #### Fixed:
 - Fixed rendering "running" page

--- a/docker/Gemfile.lock
+++ b/docker/Gemfile.lock
@@ -4,7 +4,7 @@ GEM
     erubis (2.7.0)
     mustermann (1.0.3)
     pg (1.0.0)
-    puma (3.12.3)
+    puma (3.12.6)
     que (0.14.2)
     que-web (0.7.0)
       erubis

--- a/docker/Gemfile.lock
+++ b/docker/Gemfile.lock
@@ -10,7 +10,7 @@ GEM
       erubis
       que (~> 0.8)
       sinatra
-    rack (2.0.8)
+    rack (2.2.3)
     rack-protection (2.0.7)
       rack
     sequel (5.5.0)

--- a/examples/rack/Gemfile.lock
+++ b/examples/rack/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ../..
   specs:
-    que-web (0.9.2)
+    que-web (0.9.3)
       que (~> 1.0.0.beta3)
       sinatra
 
@@ -12,7 +12,7 @@ GEM
       ruby2_keywords (~> 0.0.1)
     pg (1.2.3)
     que (1.0.0.beta4)
-    rack (2.2.2)
+    rack (2.2.3)
     rack-protection (2.0.8.1)
       rack
     ruby2_keywords (0.0.2)

--- a/lib/que/web.rb
+++ b/lib/que/web.rb
@@ -63,7 +63,7 @@ module Que
         updated_rows = Que.execute SQL[:reschedule_job], [job_id, run_at]
         if updated_rows.empty?
           # Didn't get the advisory lock
-          set_flash "warning", "Job #{job_id} not rescheduled as it was already runnning"
+          set_flash "warning", "Job #{job_id} not rescheduled as it was already running"
         else
           set_flash "info", "Job #{job_id} rescheduled for #{run_at}"
         end
@@ -101,7 +101,7 @@ module Que
 
         if updated_rows.empty?
           # Didn't get the advisory lock
-          set_flash "warning", "Job #{job_id} not deleted as it was already runnning"
+          set_flash "warning", "Job #{job_id} not deleted as it was already running"
         else
           set_flash "info", "Job #{job_id} deleted"
         end

--- a/lib/que/web/sql.rb
+++ b/lib/que/web/sql.rb
@@ -52,7 +52,7 @@ Que::Web::SQL = {
       WHERE locktype = 'advisory'
     ) locks ON (que_jobs.id=locks.job_id)
     WHERE
-      job_class LIKE ($1)
+      job_class ILIKE ($1)
       OR que_jobs.args #>> '{0, job_class}' ILIKE ($1)
   SQL
   failing_jobs: <<-SQL.freeze,
@@ -66,7 +66,7 @@ Que::Web::SQL = {
     WHERE locks.job_id IS NULL
       AND error_count > 0
       AND (
-        job_class LIKE ($3)
+        job_class ILIKE ($3)
         OR que_jobs.args #>> '{0, job_class}' ILIKE ($3)
       )
     ORDER BY run_at
@@ -84,7 +84,7 @@ Que::Web::SQL = {
     WHERE locks.job_id IS NULL
       AND error_count = 0
       AND (
-        job_class LIKE ($3)
+        job_class ILIKE ($3)
         OR que_jobs.args #>> '{0, job_class}' ILIKE ($3)
       )
     ORDER BY run_at

--- a/lib/que/web/sql.rb
+++ b/lib/que/web/sql.rb
@@ -70,7 +70,7 @@ Que::Web::SQL = {
         job_class ILIKE ($3)
         OR que_jobs.args #>> '{0, job_class}' ILIKE ($3)
       )
-    ORDER BY run_at
+    ORDER BY run_at, id
     LIMIT $1::int
     OFFSET $2::int
   SQL
@@ -88,7 +88,7 @@ Que::Web::SQL = {
         job_class ILIKE ($3)
         OR que_jobs.args #>> '{0, job_class}' ILIKE ($3)
       )
-    ORDER BY run_at
+    ORDER BY run_at, id
     LIMIT $1::int
     OFFSET $2::int
   SQL

--- a/lib/que/web/sql.rb
+++ b/lib/que/web/sql.rb
@@ -20,7 +20,8 @@ def reschedule_all_jobs_query(scope)
   <<-SQL.freeze
     WITH target AS (#{scope})
     UPDATE que_jobs
-    SET run_at = $1::timestamptz
+    SET run_at = $1::timestamptz,
+        expired_at = NULL
     FROM target
     WHERE target.locked
     AND target.id = que_jobs.id
@@ -97,7 +98,8 @@ Que::Web::SQL = {
   reschedule_job: <<-SQL.freeze,
     WITH target AS (#{lock_job_sql})
     UPDATE que_jobs
-    SET run_at = $2::timestamptz
+    SET run_at = $2::timestamptz,
+        expired_at = NULL
     FROM target
     WHERE target.locked
     AND target.id = que_jobs.id

--- a/que-web.gemspec
+++ b/que-web.gemspec
@@ -4,7 +4,7 @@ $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 
 Gem::Specification.new do |spec|
   spec.name          = "que-web"
-  spec.version       = "0.9.2"
+  spec.version       = "0.9.3"
   spec.authors       = ["Jason Staten", "Bruno Porto"]
   spec.email         = ["jstaten07@gmail.com", "brunotporto@gmail.com"]
   spec.summary       = %q{A web interface for the que queue}


### PR DESCRIPTION
Rebasing from the original que-web gem. This includes a fix that allows "retry all" to reset the expired_at column to null. This will allow expired jobs to be retried as well. 

[ITD-940](https://homestarsinc.atlassian.net/browse/ITD-940)

