### PR TITLE
Jobs with completed remote_events are not failed

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,127 @@
 /.bundle/
+### District Project Custom
+Brewfile.lock.json
+.jira-link
+snippets.*
+log
+
+# Keep .env.development local
+.env.development
+
+# Created by https://www.gitignore.io/api/rails,macos,vagrant
+# Edit at https://www.gitignore.io/?templates=rails,macos,vagrant
+
+### macOS ###
+# General
+.DS_Store
+.AppleDouble
+.LSOverride
+.idea
+
+# Icon must end with two \r
+Icon
+
+# Thumbnails
+._*
+
+# Files that might appear in the root of a volume
+.DocumentRevisions-V100
+.fseventsd
+.Spotlight-V100
+.TemporaryItems
+.Trashes
+.VolumeIcon.icns
+.com.apple.timemachine.donotpresent
+
+# Directories potentially created on remote AFP share
+.AppleDB
+.AppleDesktop
+Network Trash Folder
+Temporary Items
+.apdisk
+
+### Rails ###
+*.rbc
+capybara-*.html
+.rspec
+/db/*.sqlite3
+/db/*.sqlite3-journal
+/public/system
+/coverage/
+/spec/tmp
+*.orig
+rerun.txt
+pickle-email-*.html
+/spec/pacts
+
+# Ignore all logfiles and tempfiles.
+/log/*
+/tmp/*
+!/log/.keep
+!/tmp/.keep
+
+# TODO Comment out this rule if you are OK with secrets being uploaded to the repo
+config/initializers/secret_token.rb
+config/master.key
+
+# Only include if you have production secrets in this file, which is no longer a Rails default
+# config/secrets.yml
+
+# dotenv
+# TODO Comment out this rule if environment variables can be committed
+.env
+
+## Environment normalization:
+/.bundle
+/vendor/bundle
+
+# these should all be checked in to normalize the environment:
+# Gemfile.lock, .ruby-version, .ruby-gemset
+
+# unless supporting rvm < 1.11.0 or doing something fancy, ignore this:
+.rvmrc
+
+# if using bower-rails ignore default bower_components path bower.json files
+/vendor/assets/bower_components
+*.bowerrc
+bower.json
+
+# Ignore pow environment settings
+.powenv
+
+# Ignore Byebug command history file.
+.byebug_history
+
+# Ignore node_modules
+node_modules/
+
+# Ignore precompiled javascript packs
+/public/packs
+/public/packs-test
+/public/assets
+
+# Ignore yarn files
+/yarn-error.log
+yarn-debug.log*
+.yarn-integrity
+
+# Ignore uploaded files in development
+/storage/*
+!/storage/.keep
+
+### Vagrant ###
+# General
+.vagrant/*
+
+# Log files (if you are creating logs in debug mode, uncomment this)
+# *.log
+
+### Vagrant Patch ###
+*.box
+
+# End of https://www.gitignore.io/api/rails,macos,vagrant
+
+examples.txt
 /.yardoc
 /Gemfile.lock
 /_yardoc/

--- a/lib/que/web.rb
+++ b/lib/que/web.rb
@@ -102,12 +102,28 @@ module Que
       erb :errored
     end
 
+    get "/queued" do
+      stats = Que.execute SQL[:dashboard_stats], [search]
+      pager = get_pager stats[0][:queued]
+      queued_jobs = Que.execute SQL[:queued_jobs], [pager.page_size, pager.offset, search]
+      @list = Viewmodels::JobList.new(queued_jobs, pager)
+      erb :queued
+    end
+
     get "/scheduled" do
       stats = Que.execute SQL[:dashboard_stats], [search]
       pager = get_pager stats[0][:scheduled]
       scheduled_jobs = Que.execute SQL[:scheduled_jobs], [pager.page_size, pager.offset, search]
       @list = Viewmodels::JobList.new(scheduled_jobs, pager)
       erb :scheduled
+    end
+
+    get "/failed" do
+      stats = Que.execute SQL[:dashboard_stats], [search]
+      pager = get_pager stats[0][:failed]
+      failed_jobs = Que.execute SQL[:failed_jobs], [pager.page_size, pager.offset, search]
+      @list = Viewmodels::JobList.new(failed_jobs, pager)
+      erb :failed
     end
 
     get "/jobs/:id" do |id|

--- a/lib/que/web/sql.rb
+++ b/lib/que/web/sql.rb
@@ -42,17 +42,20 @@ end
 
 Que::Web::SQL = {
   dashboard_stats: <<-SQL.freeze,
-    SELECT count(*)                    AS total,
-           count(locks.job_id)         AS running,
-           coalesce(sum((error_count > 0 AND locks.job_id IS NULL AND finished_at is NULL)::int), 0) AS failing,
-           coalesce(sum((error_count = 0 AND locks.job_id IS NULL AND finished_at is NULL)::int), 0) AS scheduled,
-           coalesce(sum((error_count > 0 AND finished_at is not NULL)::int), 0) AS errored
+    SELECT count(*) AS total,
+    count(locks.job_id) AS running,
+    coalesce(sum((COALESCE(locks.job_id::varchar, finished_at::varchar, expired_at::varchar) is NULL AND run_at <= now())::int), 0) AS queued,
+    coalesce(sum((COALESCE(locks.job_id::varchar, finished_at::varchar, expired_at::varchar) is NULL AND run_at > now() AND (error_count = 0 OR chi_remote_events.processed_at IS NOT NULL))::int), 0) AS scheduled,
+    coalesce(sum((COALESCE(locks.job_id::varchar, finished_at::varchar, expired_at::varchar, chi_remote_events.processed_at::varchar) is NULL AND chi_remote_events.id is NOT NULL AND error_count > 0 AND run_at > now())::int), 0) AS failing,
+    coalesce(sum((error_count > 0 AND finished_at is not NULL)::int), 0) AS errored,
+    coalesce(sum((locks.job_id IS NULL AND expired_at is NOT NULL)::int), 0) AS failed
     FROM que_jobs
     LEFT JOIN (
       SELECT (classid::bigint << 32) + objid::bigint AS job_id
       FROM pg_locks
       WHERE locktype = 'advisory'
     ) locks ON (que_jobs.id=locks.job_id)
+    LEFT JOIN chi_remote_events on (CASE WHEN que_jobs.args->>0~E'[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$' THEN (que_jobs.args->>0)::uuid ELSE NULL END) = chi_remote_events.id
     WHERE
       job_class ILIKE ($1)
       OR que_jobs.args #>> '{0, job_class}' ILIKE ($1)
@@ -102,6 +105,7 @@ Que::Web::SQL = {
     LIMIT $1::int
     OFFSET $2::int
   SQL
+  # Failing - Any unfinished/not expired job that is not running, has errors and does not have a completed remote_event and is future scheduled
   failing_jobs: <<-SQL.freeze,
     SELECT que_jobs.*
     FROM que_jobs
@@ -110,11 +114,10 @@ Que::Web::SQL = {
       FROM pg_locks
       WHERE locktype = 'advisory'
     ) locks ON (que_jobs.id=locks.job_id)
-    LEFT JOIN chi_remote_events on (que_jobs.args->>0)::uuid = chi_remote_events.id
-    WHERE locks.job_id IS NULL
+    LEFT JOIN chi_remote_events on (CASE WHEN que_jobs.args->>0~E'[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$' THEN (que_jobs.args->>0)::uuid ELSE NULL END) = chi_remote_events.id
+    WHERE COALESCE(locks.job_id::varchar, finished_at::varchar, expired_at::varchar, chi_remote_events.processed_at::varchar) is NULL
+      AND run_at > now()
       AND error_count > 0
-      AND finished_at is NULL
-      AND chi_remote_events.processed_at IS NULL
       AND (
         job_class ILIKE ($3)
         OR que_jobs.args #>> '{0, job_class}' ILIKE ($3)
@@ -123,14 +126,41 @@ Que::Web::SQL = {
     LIMIT $1::int
     OFFSET $2::int
   SQL
+  # Errored - Any finished job with errors
   errored_jobs: <<-SQL.freeze,
     SELECT que_jobs.*
     FROM que_jobs
-    WHERE error_count > 0 AND finished_at is not NULL AND job_class LIKE ($3)
+    LEFT JOIN (
+      SELECT (classid::bigint << 32) + objid::bigint AS job_id
+      FROM pg_locks
+      WHERE locktype = 'advisory'
+    ) locks ON (que_jobs.id=locks.job_id)
+    WHERE error_count > 0 AND finished_at is not NULL
+      AND job_class LIKE ($3)
     ORDER BY finished_at
     LIMIT $1::int
     OFFSET $2::int
   SQL
+  # Queued - Any unfinished/not expired job that is not running and is past scheduled
+  queued_jobs: <<-SQL.freeze,
+    SELECT que_jobs.*
+    FROM que_jobs
+    LEFT JOIN (
+      SELECT (classid::bigint << 32) + objid::bigint AS job_id
+      FROM pg_locks
+      WHERE locktype = 'advisory'
+    ) locks ON (que_jobs.id=locks.job_id)
+    WHERE COALESCE(locks.job_id::varchar, finished_at::varchar, expired_at::varchar) is NULL
+      AND run_at <= now()
+      AND (
+        job_class ILIKE ($3)
+        OR que_jobs.args #>> '{0, job_class}' ILIKE ($3)
+      )
+    ORDER BY run_at, id
+    LIMIT $1::int
+    OFFSET $2::int
+  SQL
+  # Scheduled - Any unfinished/not expired job that is not running, has no errors OR has a completed remote_event, and is future scheduled
   scheduled_jobs: <<-SQL.freeze,
     SELECT que_jobs.*
     FROM que_jobs
@@ -139,9 +169,30 @@ Que::Web::SQL = {
       FROM pg_locks
       WHERE locktype = 'advisory'
     ) locks ON (que_jobs.id=locks.job_id)
-    WHERE locks.job_id IS NULL
-      AND error_count = 0
-      AND finished_at is NULL
+    LEFT JOIN chi_remote_events on (CASE WHEN que_jobs.args->>0~E'[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$' THEN (que_jobs.args->>0)::uuid ELSE NULL END) = chi_remote_events.id
+    WHERE COALESCE(locks.job_id::varchar, finished_at::varchar, expired_at::varchar) is NULL
+      AND run_at > now()
+      -- It has a future date and (no errors OR a completed remote_event)
+      AND (error_count = 0 OR chi_remote_events.processed_at IS NOT NULL)
+
+      AND (
+        job_class ILIKE ($3)
+        OR que_jobs.args #>> '{0, job_class}' ILIKE ($3)
+      )
+    ORDER BY run_at, id
+    LIMIT $1::int
+    OFFSET $2::int
+  SQL
+  # Failed - Any expired job
+  failed_jobs: <<-SQL.freeze,
+    SELECT que_jobs.*
+    FROM que_jobs
+    LEFT JOIN (
+      SELECT (classid::bigint << 32) + objid::bigint AS job_id
+      FROM pg_locks
+      WHERE locktype = 'advisory'
+    ) locks ON (que_jobs.id=locks.job_id)
+      WHERE expired_at is not NULL
       AND (
         job_class ILIKE ($3)
         OR que_jobs.args #>> '{0, job_class}' ILIKE ($3)

--- a/lib/que/web/sql.rb
+++ b/lib/que/web/sql.rb
@@ -110,9 +110,11 @@ Que::Web::SQL = {
       FROM pg_locks
       WHERE locktype = 'advisory'
     ) locks ON (que_jobs.id=locks.job_id)
+    LEFT JOIN chi_remote_events on (que_jobs.args->>0)::uuid = chi_remote_events.id
     WHERE locks.job_id IS NULL
       AND error_count > 0
       AND finished_at is NULL
+      AND chi_remote_events.processed_at IS NULL
       AND (
         job_class ILIKE ($3)
         OR que_jobs.args #>> '{0, job_class}' ILIKE ($3)

--- a/lib/que/web/viewmodels/dashboard.rb
+++ b/lib/que/web/viewmodels/dashboard.rb
@@ -1,5 +1,5 @@
 module Que::Web::Viewmodels
-  class Dashboard < Struct.new(:running, :scheduled, :failing, :errored)
+  class Dashboard < Struct.new(:running, :queued, :scheduled, :failing, :errored, :failed)
     def initialize(stats)
       members.each do |m|
         self[m] = stats[m]

--- a/que-web.gemspec
+++ b/que-web.gemspec
@@ -24,4 +24,5 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "bundler", ">= 1.6"
   spec.add_development_dependency "rake", ">= 10.0"
   spec.add_development_dependency "minitest", "~> 5.6"
+  spec.add_development_dependency "pg_query"
 end

--- a/spec/sql_spec.rb
+++ b/spec/sql_spec.rb
@@ -1,0 +1,14 @@
+require "spec_helper"
+require "pg_query"
+
+describe Que::Web::SQL do
+  it "has valid SQL" do
+    Que::Web::SQL.keys.each do |key|
+      begin
+        PgQuery.parse(Que::Web::SQL[key])
+      rescue
+        raise "Invalid SQL detected in Que::Web::SQL for '#{key}'"
+      end
+    end
+  end
+end

--- a/spec/viewmodels/dashboard_spec.rb
+++ b/spec/viewmodels/dashboard_spec.rb
@@ -3,15 +3,37 @@ require "spec_helper"
 describe Que::Web::Viewmodels::Dashboard do
   let(:dashboard_stats) {
     {
-      total: 10,
       running: 6,
-      failing: 2,
-      scheduled: 2
+      queued: 2,
+      scheduled: 3,
+      failing: 4,
+      errored: 5,
+      failed: 6
     }
   }
   let(:subject) { Que::Web::Viewmodels::Dashboard.new(dashboard_stats) }
 
-  it 'passes through values' do
-    _(subject.scheduled).must_equal 2
+  it 'passes through running' do
+    _(subject.running).must_equal 6
+  end
+
+  it 'passes through queued' do
+    _(subject.queued).must_equal 2
+  end
+
+  it 'passes through scheduled' do
+    _(subject.scheduled).must_equal 3
+  end
+
+  it 'passes through failing' do
+    _(subject.failing).must_equal 4
+  end
+
+  it 'passes through errored' do
+    _(subject.errored).must_equal 5
+  end
+
+  it 'passes through failed' do
+    _(subject.failed).must_equal 6
   end
 end

--- a/web/public/styles/application.css
+++ b/web/public/styles/application.css
@@ -25,12 +25,20 @@
   margin: 0;
 }
 
-.dashboard-stat.scheduled {
-  background: #828E8C;
+.dashboard-stat.failed {
+  background: #d65c3b;
 }
 
 .dashboard-stat.running {
   background: #CFD0C1;
+}
+
+.dashboard-stat.queued {
+  background: #b8b9ac;
+}
+
+.dashboard-stat.scheduled {
+  background: #828E8C;
 }
 
 .dashboard-stat.failing {

--- a/web/views/failed.erb
+++ b/web/views/failed.erb
@@ -1,0 +1,63 @@
+<div class="row">
+  <div class="small-12 medium-8 columns">
+    <h1><%= @list.total %> Failed Job<%= @list.total == 1 ? "" : "s" %></h1>
+  </div>
+  <div class="small-12 medium-4 columns">
+    <%= erb :_search %>
+  </div>
+</div>
+<div class="row">
+  <div class="small-12 columns">
+    <table>
+      <thead>
+        <tr>
+          <th>Failed</th>
+          <th>Failures</th>
+          <th>Job</th>
+          <th>Queue</th>
+          <th>Args</th>
+          <th>Error</th>
+          <th></th>
+          <th></th>
+        </tr>
+      </thead>
+      <tbody>
+        <% @list.page_jobs.each do |job| %>
+          <tr>
+            <td><a href="<%= link_to "jobs/#{job.id}" %>">
+              <%= relative_time job.expired_at %></a>
+              <%= erb :_past_due, locals: {job: job} %>
+            </td>
+            <td><%= job.error_count %></td>
+            <td><%= h job.humanized_job_class %></td>
+            <td><%= job.queue %></td>
+            <td><pre><%= h format_args job %></pre></td>
+            <td><pre><%= h format_error job %></pre></td>
+            <td>
+              <form action="<%= link_to "jobs/#{job.id}" %>" method="post">
+                <input type="hidden" name="_method" value="put" />
+                <button class="plain" title="Retry Immediately"><i class="fa fa-refresh"></i></button>
+              </form>
+            </td>
+          </tr>
+        <% end %>
+      </tbody>
+    </table>
+
+  </div>
+</div>
+<div class="row">
+  <div class="small-8 columns">
+    <%= erb :_pager %>
+  </div>
+  <% if @list.total > 0 %>
+    <div class="small-4 columns text-right">
+      <form action="<%= link_to "jobs" %>" method="post" class="form-inline"
+            onsubmit="return confirm('Retry all <%= @list.total %> jobs?');">
+        <input type="hidden" name="_method" value="put" />
+        <input type="hidden" name="scope" value="failing" />
+        <button class="button small" title="Retry All Immediately"><i class="fa fa-refresh"></i> Retry All</button>
+      </form>
+    </div>
+  <% end %>
+</div>

--- a/web/views/index.erb
+++ b/web/views/index.erb
@@ -17,6 +17,29 @@
       </div>
     </div>
   </a>
+   <a class="small-12 large-6 columns" href="<%= link_to 'queued' %>">
+    <div class="dashboard-stat queued">
+      <div class="cell">
+        <h2>Queued</h2>
+        <span class="dashboard-value">
+          <%= @dashboard.queued %>
+        </span>
+      </div>
+    </div>
+  </a>
+</div>
+
+<div class="row">
+  <a class="small-12 large-6 columns" href="<%= link_to 'scheduled' %>">
+    <div class="dashboard-stat scheduled">
+      <div class="cell">
+        <h2>Scheduled</h2>
+        <span class="dashboard-value">
+          <%= @dashboard.scheduled %>
+        </span>
+      </div>
+    </div>
+  </a>
   <a class="small-12 large-6 columns" href="<%= link_to 'failing' %>">
     <div class="dashboard-stat failing">
       <div class="cell">
@@ -28,13 +51,14 @@
     </div>
   </a>
 </div>
+
 <div class="row">
-  <a class="small-12 large-6 columns" href="<%= link_to 'scheduled' %>">
-    <div class="dashboard-stat scheduled">
+  <a class="small-12 large-6 columns" href="<%= link_to 'failed' %>">
+    <div class="dashboard-stat failed">
       <div class="cell">
-        <h2>Scheduled</h2>
+        <h2>Failed</h2>
         <span class="dashboard-value">
-          <%= @dashboard.scheduled %>
+          <%= @dashboard.failed %>
         </span>
       </div>
     </div>

--- a/web/views/queued.erb
+++ b/web/views/queued.erb
@@ -1,0 +1,40 @@
+<div class="row">
+  <div class="small-12 medium-8 columns">
+    <h1><%= @list.total %> Queued Job<%= @list.total == 1 ? "" : "s" %></h1>
+  </div>
+  <div class="small-12 medium-4 columns">
+    <%= erb :_search %>
+  </div>
+</div>
+<div class="row">
+  <div class="small-12 columns">
+    <table>
+      <thead>
+        <tr>
+          <th>Queued</th>
+          <th>Job</th>
+          <th>Queue</th>
+          <th>Args</th>
+        </tr>
+      </thead>
+      <tbody>
+        <% @list.page_jobs.each do |job| %>
+          <tr>
+            <td>
+              <a href="<%= link_to "jobs/#{job.id}" %>"><%= relative_time job.run_at %></a>
+              <%= erb :_past_due, locals: {job: job} %>
+            </td>
+            <td><%= h job.humanized_job_class %></td>
+            <td><%= h job.queue %></td>
+            <td><pre><%= h format_args(job) %></pre></td>
+          </tr>
+        <% end %>
+      </tbody>
+    </table>
+  </div>
+</div>
+<div class="row">
+  <div class="small-8 columns">
+    <%= erb :_pager %>
+  </div>
+</div>


### PR DESCRIPTION
Context
- Currently in Chi, the Sweeper processes all prior outstanding events, while leaving the associated Que job behind; it shows up in the dashboard as 'failing'. On a subsequent run, it will see that it's remote event has been processed and complete without error.
- Listing these jobs as 'failing' is misleading; it really is a job that has completed, and therefore has no work to do

Changes

These changes add two new tiles to the Chi dashboard to help with debugging and to clarify what is happening:
- Queued - jobs that are ready to run, yet no Que worker has picked them up. If the Que workers are tied up, there will be a large number of jobs in the 'Queued' section. No actions are provided on the index page, as these jobs are already queued and will be picked up in oldest order as soon as a Que worker is available
- Failed - jobs that expired and will no longer be retried. These are critical to see, as the service is technically out of service if there are any expired jobs. Individual 'Retry' and 'Retry All' options are available for these jobs, in case a code deploy corrects the problem, or otherwise an external issue is resolved.
- Scheduled - changed to include future schedule jobs with a completed remote_event. i.e. jobs that will just finish quietly on their next scheduled run as they have nothing to do. 

**Note**: a simplification for thinking about the new tiles: 
Scheduled - future dated w/ no errors OR future dated with a completed remote_event attached
Failing - future dated with 1+ errors AND no completed remote_event attached - if the remote_event is marked as complete, this job will show up in scheduled
Queued - ready to run, but not running 😞 - items in this tile may have come from either 'scheduled' or 'failing'

Definitions (from the code):
  * Failing - Any unfinished/not expired job that is not running, has errors and does not have a completed remote_event and is future scheduled
  * Queued - Any unfinished/not expired job that is not running and is past scheduled
  * Scheduled - Any unfinished/not expired job that is not running, has no errors OR has a completed remote_event, and is future scheduled
  * Failed - Any expired job
  * Errored - Any finished job with errors
 
Dashboard with new tiles:

![dashboard](https://user-images.githubusercontent.com/86504/175389384-e23458ab-0ef2-463e-9868-155956f9b945.png)

Queued Index page:
![queued](https://user-images.githubusercontent.com/86504/175390977-c1664c6b-8277-4a12-bc0b-8b00fa40939b.png)

Failed Index page:

![failed](https://user-images.githubusercontent.com/86504/175390195-a4dab80f-8aed-4b0f-8ef5-971618f51d85.png)

 