### PR TITLE
Fix error count query

### DIFF
--- a/lib/que/web/sql.rb
+++ b/lib/que/web/sql.rb
@@ -47,7 +47,7 @@ Que::Web::SQL = {
     coalesce(sum((COALESCE(locks.job_id::varchar, finished_at::varchar, expired_at::varchar) is NULL AND run_at <= now())::int), 0) AS queued,
     coalesce(sum((COALESCE(locks.job_id::varchar, finished_at::varchar, expired_at::varchar) is NULL AND run_at > now() AND (error_count = 0 OR chi_remote_events.processed_at IS NOT NULL))::int), 0) AS scheduled,
     coalesce(sum((COALESCE(locks.job_id::varchar, finished_at::varchar, expired_at::varchar, chi_remote_events.processed_at::varchar) is NULL AND chi_remote_events.id is NOT NULL AND error_count > 0 AND run_at > now())::int), 0) AS failing,
-    coalesce(sum((error_count > 0 AND finished_at is not NULL)::int), 0) AS errored,
+    coalesce(sum((error_count > 0 AND finished_at is NULL)::int), 0) AS errored,
     coalesce(sum((locks.job_id IS NULL AND expired_at is NOT NULL)::int), 0) AS failed
     FROM que_jobs
     LEFT JOIN (

--- a/que-web.gemspec
+++ b/que-web.gemspec
@@ -4,7 +4,7 @@ $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 
 Gem::Specification.new do |spec|
   spec.name          = "que-web"
-  spec.version       = "0.9.6"
+  spec.version       = "0.10.1"
   spec.authors       = ["Jason Staten", "Bruno Porto"]
   spec.email         = ["jstaten07@gmail.com", "brunotporto@gmail.com"]
   spec.summary       = %q{A web interface for the que queue}


### PR DESCRIPTION
Context - The count of 'errored' jobs was zero, even if there were errored jobs to display

Fix - the SQL for errored jobs was invalid