### PR TITLE
Use fast estimate rather than inefficient count

### DIFF
--- a/lib/que/web.rb
+++ b/lib/que/web.rb
@@ -46,6 +46,7 @@ module Que
       stats = get_totals
       pager = get_pager stats[:total]
       events = Que.execute SQL[:chi_events], [pager.page_size, pager.offset, search]
+      pager.total = events.length
       @list = Viewmodels::EventList.new(events, pager)
       erb :chi_events
     end
@@ -62,6 +63,7 @@ module Que
       stats = get_totals
       pager = get_pager stats[:remote]
       events = Que.execute SQL[:chi_remote_events], [pager.page_size, pager.offset, search]
+      pager.total = events.length
       @list = Viewmodels::RemoteEventList.new(events, pager)
       erb :chi_remote_events
     end

--- a/lib/que/web/pager.rb
+++ b/lib/que/web/pager.rb
@@ -1,5 +1,6 @@
 class Que::Web::Pager
-  attr_reader :current_page, :page_size, :total, :page_count
+  attr_reader :current_page, :page_size, :page_count
+  attr_accessor :total
 
   def initialize(page_no, page_size, total)
     @current_page = page_no > 1 ? page_no : 1

--- a/lib/que/web/pager.rb
+++ b/lib/que/web/pager.rb
@@ -1,6 +1,5 @@
 class Que::Web::Pager
-  attr_reader :current_page, :page_size, :page_count
-  attr_accessor :total
+  attr_reader :current_page, :page_size, :total, :page_count
 
   def initialize(page_no, page_size, total)
     @current_page = page_no > 1 ? page_no : 1

--- a/lib/que/web/sql.rb
+++ b/lib/que/web/sql.rb
@@ -60,7 +60,7 @@ Que::Web::SQL = {
       job_class ILIKE ($1)
       OR que_jobs.args #>> '{0, job_class}' ILIKE ($1)
   SQL
-  event_count: <<-SQL.freeze,
+  event_estimated_count: <<-SQL.freeze,
     SELECT (CASE WHEN c.reltuples < 0 THEN NULL
                  WHEN c.relpages = 0 THEN float8 '0'
                  ELSE c.reltuples / c.relpages END
@@ -78,6 +78,12 @@ Que::Web::SQL = {
     ORDER BY event_order desc
     LIMIT $1::int
     OFFSET $2::int
+  SQL
+  chi_events_count: <<-SQL.freeze,
+    SELECT COUNT(*)
+    FROM chi_events
+    WHERE
+      type LIKE ($1)
   SQL
   chi_data_events: <<-SQL.freeze,
     SELECT *
@@ -103,6 +109,12 @@ Que::Web::SQL = {
     ORDER BY event_order desc
     LIMIT $1::int
     OFFSET $2::int
+  SQL
+  chi_remote_events_count: <<-SQL.freeze,
+    SELECT COUNT(*)
+    FROM chi_remote_events
+    WHERE
+      type LIKE ($1) or gateway LIKE ($1)
   SQL
   # Failing - Any unfinished/not expired job that is not running, has errors and does not have a completed remote_event and is future scheduled
   failing_jobs: <<-SQL.freeze,


### PR DESCRIPTION
The reason that que-web wasn't loading in prod was that the COUNT query was taking longer than the timeout. The estimate produced by this query is almost instantaneous, and solves the issue.

These estimates may have impacts on pagination of large datasets at very high-numbered pages (eg. if estimate is lower than actual number of records, user won't be able to click "next" to see additional records; or if estimate is higher, "next" will produce empty pages), but I decided that it was unlikely that anybody would ever actually encounter these relatively insignificant issues. The cost to remedy them doesn't match the benefits.

This has been tested in integration and appears to be working.