### PR TITLE
Remove `remote_event_order` and add `remote_order_group_sequence` and `remote_order_group_name`

### DIFF
--- a/lib/que/web/viewmodels/remote_event.rb
+++ b/lib/que/web/viewmodels/remote_event.rb
@@ -1,6 +1,6 @@
 module Que::Web::Viewmodels
   class RemoteEvent < Struct.new(
-    :id, :type, :gateway, :data, :meta, :event_order, :remote_event_order, :created_at, :processed_at
+    :id, :type, :gateway, :data, :meta, :event_order, :remote_order_group_sequence, :remote_order_group_name, :created_at, :processed_at
   )
 
     def initialize(job)

--- a/que-web.gemspec
+++ b/que-web.gemspec
@@ -4,7 +4,7 @@ $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 
 Gem::Specification.new do |spec|
   spec.name          = "que-web"
-  spec.version       = "0.10.4"
+  spec.version       = "0.11.0"
   spec.authors       = ["Jason Staten", "Bruno Porto"]
   spec.email         = ["jstaten07@gmail.com", "brunotporto@gmail.com"]
   spec.summary       = %q{A web interface for the que queue}

--- a/web/views/chi_remote_events.erb
+++ b/web/views/chi_remote_events.erb
@@ -15,7 +15,8 @@
           <th>type</th>
           <th>gateway</th>
           <th>event_order</th>
-          <th>remote_event_order</th>
+          <th>remote_order_group_sequence</th>
+          <th>remote_order_group_name</th>
           <th>created_at</th>
           <th>processed_at</th>
         </tr>
@@ -29,7 +30,8 @@
             <td><%= event.type %></td>
             <td><%= event.gateway %></td>
             <td><%= event.event_order %></td>
-            <td><%= event.remote_event_order %></td>
+            <td><%= event.remote_order_group_sequence %></td>
+            <td><%= event.remote_order_group_name %></td>
             <td><%= event.created_at %></td>
             <td><%= event.processed_at %></td>
           </tr>

--- a/web/views/show_remote_event.erb
+++ b/web/views/show_remote_event.erb
@@ -56,8 +56,12 @@
           <td><%= @remote_event.event_order %></td>
         </tr>
         <tr>
-          <th>Remote Event Order</th>
-          <td><%= @remote_event.remote_event_order %></td>
+          <th>Remote Order Group Sequence</th>
+          <td><%= @remote_event.remote_order_group_sequence %></td>
+        </tr>
+        <tr>
+          <th>Remote Order Group Name</th>
+          <td><%= @remote_event.remote_order_group_name %></td>
         </tr>
         <tr>
           <th>Created At</th>


### PR DESCRIPTION
The purpose of this PR is to support the new attributes added in Chi V1 and remove deprecated attributes.