### PR TITLE
Fix event count estimate returning null

### DIFF
--- a/lib/que/web/sql.rb
+++ b/lib/que/web/sql.rb
@@ -61,7 +61,7 @@ Que::Web::SQL = {
       OR que_jobs.args #>> '{0, job_class}' ILIKE ($1)
   SQL
   event_estimated_count: <<-SQL.freeze,
-    SELECT (CASE WHEN c.reltuples < 0 THEN NULL
+    SELECT (CASE WHEN c.reltuples < 0 THEN float8 '0'
                  WHEN c.relpages = 0 THEN float8 '0'
                  ELSE c.reltuples / c.relpages END
       * (pg_catalog.pg_relation_size(c.oid)

--- a/que-web.gemspec
+++ b/que-web.gemspec
@@ -4,7 +4,7 @@ $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 
 Gem::Specification.new do |spec|
   spec.name          = "que-web"
-  spec.version       = "0.11.0"
+  spec.version       = "0.11.1"
   spec.authors       = ["Jason Staten", "Bruno Porto"]
   spec.email         = ["jstaten07@gmail.com", "brunotporto@gmail.com"]
   spec.summary       = %q{A web interface for the que queue}


### PR DESCRIPTION
Pretty sure estimated row count (c.reltuples) is less than 0 when postgres hasn't stored information about estimations. Regardless, this query should never return NULL, it's currently causing an error on the event pages.